### PR TITLE
Rsk

### DIFF
--- a/source/covalent_api/constants/maps.py
+++ b/source/covalent_api/constants/maps.py
@@ -11,7 +11,8 @@ AVAILABLE_CHAIN_IDS = {
     'Binance Smart Chain': '56',
     'Avalanche C-Chain Mainnet': '43114',
     'Fuji C-Chain Testnet': '43113',
-    'Fantom Opera Mainnet': '250'
+    'Fantom Opera Mainnet': '250',
+    'RSK Mainnet': '30'
 }
 
 #Available chains id contract metadata

--- a/source/covalent_api/session.py
+++ b/source/covalent_api/session.py
@@ -6,6 +6,7 @@
 import os
 import json
 import logging
+from functools import partial
 import requests
 
 
@@ -25,6 +26,7 @@ class Session(object):
     def __init__(
             self, server_url='https://api.covalenthq.com',
             api_key=None,
+            api_key_is_username=False,
             timeout=60
     ):
         '''
@@ -37,6 +39,9 @@ class Session(object):
         envar:: COVALENT_API_KEY environment variable.
         :type api_key: string
         :param timeout: Timeout in case the server is not responding.
+        :type api_key_is_username: bool
+        :param api_key_is_username: If True, the string in api_key is the username of the request auth, rather than the password
+                                    This is how covalent does Basic Auth per https://www.covalenthq.com/docs/api/#overview--supported-networks
         :type timeout: float
         '''
         super(Session, self).__init__()
@@ -72,7 +77,10 @@ class Session(object):
         self._api_key = api_key
 
         self._request = requests.Session()
-        self._request.auth = ('', self._api_key)
+        if not api_key_is_username:
+            self._request.auth = ('', self._api_key)
+        else:
+            self._request.auth = (self._api_key, '')
 
         self.request_timeout = timeout
 

--- a/tests/test_paginate.py
+++ b/tests/test_paginate.py
@@ -1,0 +1,42 @@
+import covalent_api as cov
+from covalent_api.class_a import ClassA
+
+import unittest
+from unittest import mock
+
+
+
+class TestPaginate(unittest.TestCase):
+    def setUp(self):
+        #sess = cov.Session(timeout=10, api_key_is_username=True)
+        self.sess = mock.MagicMock()
+        self.classa = ClassA(self.sess)
+
+    def test_max_pages(self):
+        address = 'dummy address'
+        RSK_CHAIN_ID='30'
+        self.sess.query.return_value = {'error': False, 'data': {'items': ['thing1', 'thing2']}}
+
+        for result in self.classa.paginate(self.classa.get_transactions, chain_id=RSK_CHAIN_ID, address=address,
+                        page_size=1, starting_page=1, max_pages=5):
+            pass
+
+        #this gets called max_pages number of times
+        self.assertEqual(self.sess.query.call_count, 5)
+
+    def test_no_more_results(self):
+        address = 'dummy address'
+        RSK_CHAIN_ID='30'
+        self.sess.query.return_value = {'error': False, 'data': {'items': ['thing1', 'thing2']}}
+
+        for result in self.classa.paginate(self.classa.get_transactions, chain_id=RSK_CHAIN_ID, address=address,
+                        page_size=1, starting_page=1,
+                        max_pages=100):
+            self.sess.query.return_value = {'error': False, 'data': {'items': []}}
+
+        #because no data came in, it only gets called 2 times instead of max_pages=100
+        self.assertEqual(self.sess.query.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added "RSK Mainnet" with chain id 30 to the list of available chain ids.

Added convenience method "paginate" to class_a.  This handles the
pagination logic for larger queries.

Added unittest for pagination

Added "api_key_is_username" flag to session constructor.  Covalent
expects the api key to be the username (not the password) in Basic Auth
https://www.covalenthq.com/docs/api/#overview--supported-networks