### PR TITLE
fixing session in order to pass key or otherwise we get Http-401

### DIFF
--- a/source/covalent_api/session.py
+++ b/source/covalent_api/session.py
@@ -125,7 +125,7 @@ class Session(object):
             True by default.
         :type decode: boolean
         '''
-        url = "{}{}".format(self._server_url, url)
+        url = "{}{}?&key={}".format(self._server_url, url, self.api_key)
 
 
         self.logger.debug("Url: {}".format(url))

--- a/tests/test_class_a.py
+++ b/tests/test_class_a.py
@@ -1,0 +1,23 @@
+import unittest
+import covalent_api
+import mock
+import os
+
+SERVER_URL="https://api.covalenthq.com"
+
+
+class TestClass(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.APIKEY = os.environ.get('COVALENT_API_KEY')
+        if not cls.APIKEY:
+            raise Exception("Need to set COVALENT_API_KEY in order to run tests.")
+        cls.session = covalent_api.session.Session(server_url=SERVER_URL, api_key=cls.APIKEY)
+        cls.cl_a = covalent_api.class_a.ClassA(cls.session)
+
+    def test_get_transactions(self):
+        ret = self.cl_a.get_transactions(chain_id="1", address="0x74c1e4b8cae59269ec1d85d3d4f324396048f4ac")
+        print(ret)
+        assert 'data' in ret
+


### PR DESCRIPTION
Covalent now only accepts key in URL in order to authenticate each request, they were failing because of missing key in url whilst composing URL for session's query